### PR TITLE
Update mirror to no longer be broken

### DIFF
--- a/libgen_api/search_request.py
+++ b/libgen_api/search_request.py
@@ -47,11 +47,11 @@ class SearchRequest:
         query_parsed = "%20".join(self.query.split(" "))
         if self.search_type.lower() == "title":
             search_url = (
-                f"http://gen.lib.rus.ec/search.php?req={query_parsed}&column=title"
+                f"https://libgen.is/search.php?req={query_parsed}&column=title"
             )
         elif self.search_type.lower() == "author":
             search_url = (
-                f"http://gen.lib.rus.ec/search.php?req={query_parsed}&column=author"
+                f"https://libgen.is/search.php?req={query_parsed}&column=author"
             )
         search_page = requests.get(search_url)
         return search_page

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     url="https://github.com/harrison-broadbent/libgen-api",
-    download_url="https://github.com/harrison-broadbent/libgen-api/archive/v1.0.0.tar.gz",
     author="Harrison Broadbent",
     author_email="mail@harrisonbroadbent.com",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", errors="replace") as fh:
     long_description = fh.read()
 
 setuptools.setup(

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -80,7 +80,7 @@ class TestBasicSearching:
         dl_links = ls.resolve_download_links(title_to_download)
 
         # ensure each host is in the results and that they each have a url
-        assert (["GET", "Cloudflare", "IPFS.io", "Infura"] == list(dl_links.keys())) & (
+        assert (["GET", "Cloudflare", "IPFS.io"] == list(dl_links.keys())) & (
             False not in [len(link) > 0 for key, link in dl_links.items()]
         )
 


### PR DESCRIPTION
Title. In my testing, this module no longer works as intended with the old mirror (gen.lib.rus.ec) so I swapped it for a new one (libgen.is).